### PR TITLE
fix: stopped reflectheaders from affecting invoke headers

### DIFF
--- a/core/grpcox.go
+++ b/core/grpcox.go
@@ -83,6 +83,7 @@ func (g *GrpCox) GetResource(ctx context.Context, target string, plainText, isRe
 		return nil, err
 	}
 
+	// what is r.Headers used for?
 	r.headers = h
 
 	g.activeConn.addConnection(target, r, g.maxLifeConn)

--- a/core/resource.go
+++ b/core/resource.go
@@ -210,7 +210,7 @@ func (r *Resource) Invoke(ctx context.Context, metadata []string, symbol string,
 	}
 	h := grpcurl.NewDefaultEventHandler(&resultBuffer, r.descSource, formatter, false)
 
-	var headers = r.headers
+	var headers []string
 	if len(metadata) != 0 {
 		headers = metadata
 	}


### PR DESCRIPTION
Stop reflect headers from being reused in invoke headers.
- This is to stop issues where another user's grpcox request is affected by another user's request metadata.